### PR TITLE
Renamed the attribute for sorting

### DIFF
--- a/digitalproducts/elementtypes/DigitalProducts_LicenseElementType.php
+++ b/digitalproducts/elementtypes/DigitalProducts_LicenseElementType.php
@@ -194,7 +194,7 @@ class DigitalProducts_LicenseElementType extends BaseElementType
         $attributes = [
             'slug' => Craft::t('Product name'),
             'licensedTo' => Craft::t('Owner'),
-            'licenseDate' => Craft::t('License date'),
+            'dateCreated' => Craft::t('License issue date'),
         ];
 
         // Allow plugins to modify the attributes


### PR DESCRIPTION
Sorting on date now correctly reflects what is defined in the model, to enable proper sorting of licenses.
