### PR TITLE
Add fixes for #1

### DIFF
--- a/digitalproducts/models/DigitalProducts_ProductModel.php
+++ b/digitalproducts/models/DigitalProducts_ProductModel.php
@@ -174,7 +174,7 @@ class DigitalProducts_ProductModel extends BaseElementModel implements Purchasab
             $this->_isLicensed = false;
             $user = craft()->userSession->getUser();
             if ($user) {
-                $criteria = ['owner' => $user, 'product' => $this];
+                $criteria = ['owner' => $user, 'product' => $this, 'status' => static::ENABLED];
                 $license = craft()->elements->getCriteria("DigitalProducts_License", $criteria)->first();
 
                 if ($license) {
@@ -195,8 +195,7 @@ class DigitalProducts_ProductModel extends BaseElementModel implements Purchasab
     public function setEagerLoadedElements($handle, $elements)
     {
         if ($handle == 'isLicensed') {
-            $this->_isLicensed = isset($elements[0]) ? true : false;
-            return;
+            return $this->getIsLicensed();
         }
 
         parent::setEagerLoadedElements($handle, $elements);


### PR DESCRIPTION
So that when isLicensed is populated, it both actually gets checked, and that the criteria for checking also includes looking for a status of enabled.

Squashed to one commit, for nicer history :)
