### PR TITLE
Corrected developer URL

### DIFF
--- a/digitalproducts/DigitalProductsPlugin.php
+++ b/digitalproducts/DigitalProductsPlugin.php
@@ -68,7 +68,7 @@ class DigitalProductsPlugin extends BasePlugin
      */
     public function getDeveloperUrl()
     {
-        return 'https://pixelandtonic.com.com';
+        return 'https://pixelandtonic.com';
     }
 
     /**


### PR DESCRIPTION
The developer URL was returning in the incorrect URL (https://pixelandtonic.com.com) in getDeveloperUrl() method